### PR TITLE
move rebar3_hex to a project_plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 % -*- mode: Erlang; -*-
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {erl_opts, [warnings_as_errors]}.


### PR DESCRIPTION
Better is to just not have it in the project's rebar3 config and keep it global, `~/.config/rebar3/rebar.config` but at least as a `project_plugin` it will not be fetched when base32 is used as a dependency.